### PR TITLE
GVI cost function

### DIFF
--- a/src/app/graph_handler.py
+++ b/src/app/graph_handler.py
@@ -104,9 +104,9 @@ class GraphHandler:
 
                 self.graph.es[cost_attr] = [
                     noise_exps.get_noise_adjusted_edge_cost(
-                        sen, self.db_costs, noises, length, b_length
+                        sen, self.db_costs, noises, length, length_b
                     ) if has_geom else 0.0
-                    for length, b_length, noises, has_geom
+                    for length, length_b, noises, has_geom
                     in lengths_noises_b_geoms
                 ]
 
@@ -118,7 +118,6 @@ class GraphHandler:
         biking_lengths = self.graph.es[E.length_b.value]
         gvi_list = self.graph.es[E.gvi.value]
         has_geom_list = [isinstance(geom, LineString) for geom in list(self.graph.es[E.geometry.value])]
-        select_biking_length = lambda length, b_length: b_length if b_length else length
 
         for sen in gvi_exps.get_gvi_sensitivities():
             
@@ -126,7 +125,7 @@ class GraphHandler:
                 length_gvi_b_geom = zip(lengths, gvi_list, has_geom_list)
                 cost_attr = cost_prefix + str(sen)
                 self.graph.es[cost_attr] = [
-                    gvi_exps.get_gvi_adjusted_cost(length, gvi, sen) 
+                    gvi_exps.get_gvi_adjusted_cost(length, gvi, sen=sen) 
                     if has_geom else 0.0
                     for length, gvi, has_geom 
                     in length_gvi_b_geom
@@ -137,10 +136,10 @@ class GraphHandler:
                 cost_attr = cost_prefix_bike + str(sen)
                 self.graph.es[cost_attr] = [
                     gvi_exps.get_gvi_adjusted_cost(
-                        select_biking_length(length, b_length), gvi, sen
-                    ) 
+                        length, gvi, length_b=length_b, sen=sen
+                    )
                     if has_geom else 0.0
-                    for length, b_length, gvi, has_geom 
+                    for length, length_b, gvi, has_geom 
                     in length_gvi_b_geom
                 ]
 

--- a/src/app/greenery_exposures.py
+++ b/src/app/greenery_exposures.py
@@ -9,14 +9,37 @@ def get_gvi_sensitivities() -> List[float]:
     if env.gvi_sensitivities:
         return env.gvi_sensitivities
     
-    return [0.25, 0.5, 1, 1.5]
+    return [2, 4, 8]
 
 
-def get_gvi_adjusted_cost(length, gvi, sen: int = 1) -> float:
-    """TODO implement this. 
+def get_gvi_adjusted_cost(
+    length: float,
+    gvi: float,
+    length_b: float = None,
+    sen: float = 1.0
+) -> float:
+    """Calculates GVI adjusted edge cost for GVI optimized routing.
+    To find high GVI paths, we have to assign lower costs for edges with high GVI and
+    higher costs for edges with low GVI. Negative costs cannot be used (with Dijkstra's),
+    so a temporarily inverted concept (of GVI) "greyness index" is needed. 
+    Higher sensitivity coefficient will give paths of higher GVI (i.e. lower "greyness"). 
+
+    Args:
+        length (float): Length of the edge.
+        gvi (float): GVI of the edge (0-1).
+        length_b (float): Biking cost ("adjusted length") of the edge (optional, for biking).
+        sen (float): Sensitivity coefficient (optional, default = 1)
+
+    The function employs the following four assumptions: 
+        1) "greyness index" = 1 - gvi
+        2) "greyness cost" = (1 - gvi) * length
+        3) base cost = either length or length_b (if the latter is given)
+        4) GVI adjusted cost = base cost (length) + greyness cost * sensitivity
     """
+
+    base_cost = length_b if length_b else length
     
-    return length
+    return round(base_cost + (1 - gvi) * length * sen, 2)
     
 
 def get_mean_gvi(gvi_exps: List[Tuple[float, float]]) -> float:

--- a/src/tests/test_api_gvi_paths.py
+++ b/src/tests/test_api_gvi_paths.py
@@ -5,7 +5,7 @@ import pytest
 
 @pytest.fixture
 def path_set_1(client) -> dict:
-    response = client.get('/paths/bike/green/60.212031,24.968584/60.201520,24.961191')
+    response = client.get('/paths/bike/green/60.215175,24.980636/60.200423,24.961936')
     assert response.status_code == 200
     data = json.loads(response.data)
     assert len(data) == 2
@@ -80,7 +80,6 @@ def test_gvi_path_prop_types(test_exposure_prop_types) -> Callable[[dict], None]
     return test_func
 
 
-@pytest.mark.skip(reason='WIP')
 def test_path_set_1_shortest_path_prop_types(
     path_set_1, 
     test_line_geometry, 
@@ -96,7 +95,6 @@ def test_path_set_1_shortest_path_prop_types(
     test_short_path_prop_types(props)
 
 
-@pytest.mark.skip(reason='WIP')
 def test_path_set_1_gvi_path_prop_types(
     path_set_1, 
     test_line_geometry,
@@ -105,7 +103,7 @@ def test_path_set_1_gvi_path_prop_types(
     data = path_set_1
     path_fc = data['path_FC']
     gvi_paths = [feat for feat in path_fc['features'] if feat['properties']['type'] == 'green']
-    assert len(gvi_paths) == 2
+    assert len(gvi_paths) == 3
     for gp in gvi_paths:
         test_line_geometry(gp['geometry'])
         test_gvi_path_prop_types(gp['properties'])
@@ -124,7 +122,6 @@ def test_edge_props() -> Callable[[dict], None]:
     return test_func
 
 
-@pytest.mark.skip(reason='WIP')
 def test_path_set_1_edge_fc(
     path_set_1, 
     test_line_geometry, 

--- a/src/tests/test_graph_updates.py
+++ b/src/tests/test_graph_updates.py
@@ -87,4 +87,4 @@ def test_gvi_cost_edge_attributes(graph_handler):
             assert attrs[eg_gvi_cost] == 0.0
         else:
             assert attrs[eg_gvi_cost] > 0.0
-            assert round(attrs[eg_gvi_cost], 2) <= round(attrs[E.length.value], 2)
+            assert round(attrs[eg_gvi_cost], 2) >= round(attrs[E.length.value], 2)


### PR DESCRIPTION
Below is a simplified version of the new cost function - does it make more sense now? @apoom @EWillberg 

It is basically the same concept that's used in noise and AQ cost calculation. The "cognitive challenge" comes from the need to invert GVI to something negative (here "grayness") that is then used for assigning higher costs for edges of low GVI. 

```
def get_gvi_adjusted_cost(
    length: float,
    gvi: float,
    sen: float = 1.0
) -> float:
    """Calculates GVI adjusted edge cost for GVI optimized routing.
    To find high GVI paths, we have to assign lower costs for edges with high GVI and
    higher costs for edges with low GVI. Negative costs cannot be used (with Dijkstra's),
    so a temporarily inverted concept (of GVI) "greyness index" is needed. 
    Higher sensitivity coefficient will give paths of higher GVI (i.e. lower "greyness"). 

    Args:
        length (float): Length of the edge.
        gvi (float): GVI of the edge (0-1).
        sen (float): Sensitivity coefficient (optional, default = 1)

    The function employs the following three assumptions: 
        1) "greyness index" = 1 - gvi
        2) "greyness cost" = (1 - gvi) * length
        3) GVI adjusted cost = base cost (length) + greyness cost * sensitivity
    """

    return length + (1 - gvi) * length * sen
```