### PR TITLE
Add path variable for routing only shortest paths

### DIFF
--- a/docs/green_paths_api.md
+++ b/docs/green_paths_api.md
@@ -14,7 +14,7 @@ When exploring the API and the source codes, please bear in mind that the word "
 
 ## Path variables
 - travel_mode: either `walk` or `bike` 
-- exposure_mode: either `quiet`, `green` or `clean` (for fresh air paths) 
+- exposure_mode: either `quiet`, `green`, `clean` (for fresh air paths) or `short` (for shortest path only) 
 - orig/dest_coords: <latitude,longitude>, e.g. 60.20772,24.96716
 
 ## Response

--- a/src/gp_server/app/constants.py
+++ b/src/gp_server/app/constants.py
@@ -7,6 +7,7 @@ class TravelMode(Enum):
     BIKE = 'bike'
 
 class RoutingMode(Enum):
+    SHORT_ONLY = 'short'
     CLEAN = 'clean' # i.e. "fresh air"
     QUIET = 'quiet'
     GREEN = 'green'

--- a/src/gp_server/app/path_finder.py
+++ b/src/gp_server/app/path_finder.py
@@ -74,8 +74,13 @@ class PathFinder:
         Raises:
             Only meaningful exception strings that can be shown in UI.
         """
-        sens = sensitivities_by_routing_mode[self.routing_mode]
-        cost_prefix = cost_prefix_dict[self.travel_mode][self.routing_mode]
+        if self.routing_mode == RoutingMode.SHORT_ONLY:
+            sens = []
+            cost_prefix = ''
+        else:
+            sens = sensitivities_by_routing_mode[self.routing_mode]
+            cost_prefix = cost_prefix_dict[self.travel_mode][self.routing_mode]
+        
         try:
             start_time = time.time()
             shortest_path = self.G.get_least_cost_path(self.orig_node['node'], self.dest_node['node'], weight=E.length.value)
@@ -139,4 +144,5 @@ class PathFinder:
             orig_edges=self.orig_link_edges,
             orig_node=self.orig_node, 
             dest_edges=self.dest_link_edges,
-            dest_node=self.dest_node)
+            dest_node=self.dest_node
+        )

--- a/src/gp_server/app/types.py
+++ b/src/gp_server/app/types.py
@@ -42,6 +42,7 @@ class PathEdge:
 
 
 edge_group_attr_by_routing_mode: Dict[RoutingMode, str] = {
+    RoutingMode.SHORT_ONLY: 'gvi_cl',
     RoutingMode.CLEAN: 'aqi_cl',
     RoutingMode.QUIET: 'db_range',
     RoutingMode.GREEN: 'gvi_cl'

--- a/src/gp_server/tests/test_api.py
+++ b/src/gp_server/tests/test_api.py
@@ -49,3 +49,15 @@ def test_aqi_map_data_response(client):
     assert response.status_code == 200
     data = json.loads(response.data)
     assert len(data['data']) == 387411 
+
+
+def test_route_only_shortest_path(client):
+    response = client.get('/paths/walk/short/60.212031,24.968584/60.201520,24.961191')
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert len(data) == 2
+    assert 'edge_FC' in data
+    assert 'path_FC' in data
+    assert data['path_FC']['type'] == 'FeatureCollection'
+    assert len(data['path_FC']['features']) == 1
+    assert len(data['edge_FC']['features']) > 1

--- a/src/gp_server/utils/paths_overlay_filter.py
+++ b/src/gp_server/utils/paths_overlay_filter.py
@@ -2,7 +2,7 @@
 This module provides functionality for filtering out paths with nearly identical geometries. 
 """
 
-from typing import List, Set, Dict, Tuple
+from typing import List, Set, Dict, Tuple, Union
 from gp_server.app.path import Path
 from gp_server.app.logger import Logger
 
@@ -61,7 +61,7 @@ def get_unique_paths_by_geom_overlay(
     all_paths: List[Path], 
     buffer_m: int = None, 
     cost_attr: str = 'nei_norm'
-) -> List[str]:
+) -> Union[List[str], None]:
     """Filters a list of paths by comparing buffered line geometries of the paths and selecting only the unique paths by given buffer_m (m).
 
     Args:


### PR DESCRIPTION
With this, routing only shortest path(s) would be as easy as calling:
[/paths/walk/short/60.20772,24.96716/60.2037,24.9653](http://localhost:5000/paths/walk/short/60.20772,24.96716/60.2037,24.9653)